### PR TITLE
BUILD-8073 Migrate public repositories workflows to large runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   jfrog-setup-internal-auth:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write
       contents: read
@@ -28,7 +28,7 @@ jobs:
         run: jfrog rt ping
 
   jfrog-setup-external-auth:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-large
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Migrates public repository workflows from standard GitHub-hosted runners to **Large Runners**
(`ubuntu-latest` → `ubuntu-latest-large`, etc.).

See [BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073) for details.


[BUILD-8073]: https://sonarsource.atlassian.net/browse/BUILD-8073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ