### PR TITLE
BUILD-10781 Bump JS deps toward Node 24 runtimes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: get secrets
         id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           url: https://vault.staging.sonar.build:8200
           secrets: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: exec jfrog-setup
         id: actual
         uses: ./
@@ -33,10 +33,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: get secrets
         id: secrets
-        uses: SonarSource/vault-action-wrapper@d6d745ffdbc82b040df839b903bc33b5592cd6b0 # 3.0.2
+        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
         with:
           url: https://vault.staging.sonar.build:8200
           secrets: |

--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ runs:
     - name: Fetch access token
       id: secrets
       if: ${{ !(inputs.jfrogAccessToken) }}
-      uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+      uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       with:
         url: ${{ inputs.vaultUrl }}
         secrets: |

--- a/action.yaml
+++ b/action.yaml
@@ -35,13 +35,13 @@ runs:
     - name: Fetch access token
       id: secrets
       if: ${{ !(inputs.jfrogAccessToken) }}
-      uses: SonarSource/vault-action-wrapper@d6d745ffdbc82b040df839b903bc33b5592cd6b0 # 3.0.2
+      uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
       with:
         url: ${{ inputs.vaultUrl }}
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ inputs.artifactoryRoleSuffix }} access_token | artifactory_access_token;
     - name: Setup JFrog CLI
-      uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
+      uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       with:
         version: ${{ inputs.jfrogCliVersion }}
         disable-auto-build-publish: ${{ inputs.disableAutoBuildPublish }}


### PR DESCRIPTION
## Why

GitHub deprecates Node 20 on Actions runners starting **2026-06-02**.

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

- `jfrog/setup-jfrog-cli` v4.5.11 → **v5.0.0** (Node 24; upstream changed default runtime).
- `SonarSource/vault-action-wrapper` 3.0.2 → **3.4.0** (refresh stale pin to current latest). Note: 3.4.0 itself is still on Node 20 internally; a follow-up bump is needed once vault-action-wrapper ships its Node 24 release (tracked in [vault-action-wrapper#75](https://github.com/SonarSource/vault-action-wrapper/pull/75)).
- `actions/checkout` v4.2.2 → **v6.0.2** in the test workflow.

## Supersedes

Renovate PR #45 (`major-github-actions`) — same `setup-jfrog-cli` + `checkout` content. The user will close that PR after this lands.

## Verification

- All hooks except markdownlint pass locally (markdownlint requires `gem` which isn't installed in my env; CI will run it). yamllint and Validate GitHub Workflows pass.
- CI on this PR exercises `test.yaml` against Vault + JFrog.


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ